### PR TITLE
Change recursive `nextTick` to `setImmediate` to free up IO

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -60,6 +60,7 @@ Queue.prototype.process = function (type, worker_fn) {
   process.nextTick(function iterateFn() {
     onEachTick.call(self, type, worker_fn, function (err) {
       if (err) self.events.emit('error', err);
+      // Let IO calls happen before polling for the next job
       setImmediate(iterateFn);
     });
   });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -60,7 +60,7 @@ Queue.prototype.process = function (type, worker_fn) {
   process.nextTick(function iterateFn() {
     onEachTick.call(self, type, worker_fn, function (err) {
       if (err) self.events.emit('error', err);
-      process.nextTick(iterateFn);
+      setImmediate(iterateFn);
     });
   });
 };


### PR DESCRIPTION
>all callbacks passed to process.nextTick() will be resolved before the event loop continues. This can create some bad situations because it allows you to "starve" your I/O by making recursive process.nextTick() calls, which prevents the event loop from reaching the poll phase.

https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/